### PR TITLE
Add `--extract` to move_locales.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,4 @@ A python script which behaves similar to the old `manage:translations` command, 
 | ------- | ----------- |
 | -i --in | path to upstream locales |
 | -o --out | path to new locales |
+| -e --extract | Copies translations instead of moving them |

--- a/move_locales.py
+++ b/move_locales.py
@@ -5,10 +5,12 @@ from pathlib import Path
 parser = argparse.ArgumentParser()
 parser.add_argument('-i', '--in', type=Path, help='Path to locales to extract', dest='input')
 parser.add_argument('-o', '--out', type=Path, help='Path to new locales', dest='output')
+parser.add_argument('-e', '--extract', action=argparse.BooleanOptionalAction, help='Do not delete from input', dest='extract')
 
 args = parser.parse_args()
-outputPath = args.output # './app/javascript/flavours/polyam/locales'
+outputPath = args.output
 inputPath = args.input
+extract = args.extract
 
 file = Path(outputPath, 'en.json')
 data = {}
@@ -47,10 +49,11 @@ for child in Path(inputPath).glob('*.json'):
         with open(newFile, 'w') as newLocaleFile:
           newLocaleFile.write(json.dumps(newData, sort_keys=True, indent=2, ensure_ascii=False) + '\n')
 
-    # Open file again in write mode and delete strings present in en.json
-    with open(child, 'w') as localeFile:
-      for attr in to_delete:
-        del lines[attr]
+    if not extract:
+      # Open file again in write mode and delete strings present in en.json
+      with open(child, 'w') as localeFile:
+        for attr in to_delete:
+          del lines[attr]
 
-      localeFile.write(json.dumps(lines, sort_keys=True, indent=2, ensure_ascii=False) + '\n')
+        localeFile.write(json.dumps(lines, sort_keys=True, indent=2, ensure_ascii=False) + '\n')
 


### PR DESCRIPTION
Copies translations from input to output instead of moving them.