### PR TITLE
Rename `--extract` to `--copy` in `move_locales.py`

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ A python script which behaves similar to the old `manage:translations` command, 
 | ------- | ----------- |
 | -i --in | path to upstream locales |
 | -o --out | path to new locales |
-| -e --extract | Copies translations instead of moving them |
+| -c --copy | Copies translations instead of moving them |
 
 ### toot_keeper
 A python script checking english locale files in project dir for uses of "post" instead of "toot".

--- a/move_locales.py
+++ b/move_locales.py
@@ -5,12 +5,12 @@ from pathlib import Path
 parser = argparse.ArgumentParser()
 parser.add_argument('-i', '--in', type=Path, help='Path to locales to extract', dest='input')
 parser.add_argument('-o', '--out', type=Path, help='Path to new locales', dest='output')
-parser.add_argument('-e', '--extract', action=argparse.BooleanOptionalAction, help='Do not delete from input', dest='extract')
+parser.add_argument('-c', '--copy', action=argparse.BooleanOptionalAction, help='Do not delete from input', dest='copy')
 
 args = parser.parse_args()
 outputPath = args.output
 inputPath = args.input
-extract = args.extract
+copy = args.copy
 
 file = Path(outputPath, 'en.json')
 data = {}
@@ -49,7 +49,7 @@ for child in Path(inputPath).glob('*.json'):
         with open(newFile, 'w') as newLocaleFile:
           newLocaleFile.write(json.dumps(newData, sort_keys=True, indent=2, ensure_ascii=False) + '\n')
 
-    if not extract:
+    if not copy:
       # Open file again in write mode and delete strings present in en.json
       with open(child, 'w') as localeFile:
         for attr in to_delete:


### PR DESCRIPTION
Extract is an unfitting name for that option, since extracting is the default behaviour.

Rename it to "copy" to make it clear what it does.