### PR TITLE
Remove duplicate `yarn install` run

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -161,9 +161,9 @@ if [[ ! "$SKIP_PRECOMPILE" ]];then
 
   echo "Precompiling assets... This might take a while"
   if [[ "$LEGACY" ]]; then
-    sudo -u "$MASTODONUSER" NODE_OPTIONS=--openssl-legacy-provider RAILS_ENV=production bundle exec rails yarn:install assets:precompile
+    sudo -u "$MASTODONUSER" NODE_OPTIONS=--openssl-legacy-provider RAILS_ENV=production bundle exec rails assets:precompile
   else
-    sudo -u "$MASTODONUSER" RAILS_ENV=production bundle exec rails yarn:install assets:precompile
+    sudo -u "$MASTODONUSER" RAILS_ENV=production bundle exec rails assets:precompile
   fi
 fi
 


### PR DESCRIPTION
It's not necessary to run this while compiling assets as it's already run earlier and not skippable.