### PR TITLE
Add `--ignored-keys` argument to tootkeeper

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,4 @@ A python script checking english locale files in project dir for uses of "post" 
 | options | description |
 | ------- | ----------- |
 | -p --path | path to source dir |
+| -i --ignored-keys | keys to ignore |

--- a/toot_keeper.py
+++ b/toot_keeper.py
@@ -8,9 +8,11 @@ from pathlib import Path
 
 parser = argparse.ArgumentParser()
 parser.add_argument('-p', '--project', type=Path, help='Path to Mastodon source dir to check', default='.')
+parser.add_argument('-i', '--ignored-keys', nargs='*', help='Locale keys to ignore', default=['dmca_address'])
 
 args = parser.parse_args()
 projectPath = args.project
+ignoredKeys = args.ignored_keys
 
 frontendPaths = ['app/javascript/mastodon/locales', 'app/javascript/flavours/glitch/locales', 'app/javascript/flavours/polyam/locales']
 backendPaths = ['config/locales', 'config/locales-glitch', 'config/locales-polyam']
@@ -41,7 +43,7 @@ def check_files(paths):
           exit(2)
       
       for key, localeString in data:
-        if localeString is not None and 'post'.casefold() in localeString.casefold():
+        if localeString is not None and 'post'.casefold() in localeString.casefold() and key not in ignoredKeys:
           print(f'{localeFile.relative_to(projectPath)}: {key} contains "post" instead of "toot"')
 
 check_files(frontendPaths + backendPaths)


### PR DESCRIPTION
This allows a given list of strings to contain "post", which will then be ignored.

One example of such a string is `dmca_address` which contains "post" but with a different meaning.

There might be more such strings in the future, or someone might want to ignore specific strings for whatever reason, so this is more flexible than having a set list.