### PR TITLE
Install corepack when yarn is missing in update script

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -156,6 +156,15 @@ if [[ $RUBY_VERSION ]];then
   echo "$RUBY_VERSION" > .ruby-version
 fi
 
+# corepack is no longer included in node package
+# and has to be installed separately.
+# That might make yarn unavailable after updating node,
+# so install corepack when yarn can't be found.
+if ! type "yarn" > /dev/null 2>&1; then
+  echo "yarn not found. Installing corepack..."
+  npm install -g corepack
+fi
+
 # Install dependencies
 echo "Installing dependencies..."
 sudo -u "$MASTODONUSER" bundle install && sudo -u "$MASTODONUSER" yarn install --immutable


### PR DESCRIPTION
Corepack is no longer included in node and this may fail the script on node version bumps, because yarn isn't available.

This fixes that by installing corepack when yarn command is missing.